### PR TITLE
fix(rss-monitor): increase max-age for delayed releases

### DIFF
--- a/.github/workflows/rss-monitor.yml
+++ b/.github/workflows/rss-monitor.yml
@@ -20,6 +20,6 @@ jobs:
           feed: https://lizardbyte.github.io/feed.xml
           character-limit: 0
           dry-run: false
-          max-age: 48h
+          max-age: 168h
           labels: blog
           url-only: true


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
If a release is delayed more than 48h it would not register in the rss monitor. Let's bump this up to one week for good measure.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
